### PR TITLE
Problem: GraphQLCommand is coupled with a GraphQLMutationProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,9 @@ them in OSGi.
 ```java
 @Accessors(fluent = true)
 @GraphQLName("test")
-public static class TestCommand extends GraphQLCommand<String> implements GraphQLMutationProvider {
+public static class TestCommand extends GraphQLCommand<String> {
     @Getter(onMethod = @__(@GraphQLField)) @Setter
     private String value;
-
-    public TestCommand() {
-        super(Result.class);
-    }
 
     public Stream<Event> events(Repository repository) {
          return Stream.of(...);
@@ -54,8 +50,9 @@ public static class TestCommand extends GraphQLCommand<String> implements GraphQ
 }
 ```
 
-Since it implements `GraphQLMutationProvider`, it can be bound to the servlet
-and will be automatically exposed as `test(input: {value: <string>, clientMutationId: <string>})`
+There are two ways to expose such commands, one is to use `PackageGrapgQLMutationProvider` to scan
+all relevant packages to find subclasses of `GraphQLCommand` in those packages. For OSGi environments,
+`BundleGraphQLMutationProvider` should be used to scan relevant bundles.
 
 ## Domain models as queries
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 license {
-        header file('LICENSE-HEADER')
+    header file('LICENSE-HEADER')
 }
 
 jar {
@@ -97,6 +97,9 @@ dependencies {
 
     // Useful utilities
     compile 'com.google.guava:guava:19.0'
+
+    // Reflections API
+    compile 'org.reflections:reflections:0.9.10'
 
     // Unit testing
     testCompile 'org.testng:testng:6.9.10'

--- a/src/main/java/com/eventsourcing/graphql/AbstractGraphQLMutationProvider.java
+++ b/src/main/java/com/eventsourcing/graphql/AbstractGraphQLMutationProvider.java
@@ -1,0 +1,118 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.graphql;
+
+import com.eventsourcing.Entity;
+import com.eventsourcing.layout.Layout;
+import com.eventsourcing.layout.Property;
+import graphql.annotations.GraphQLAnnotations;
+import graphql.schema.*;
+import graphql.servlet.GraphQLMutationProvider;
+import lombok.SneakyThrows;
+
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+
+import static graphql.Scalars.GraphQLString;
+import static graphql.schema.GraphQLArgument.newArgument;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
+
+public abstract class AbstractGraphQLMutationProvider implements GraphQLMutationProvider {
+
+    protected Predicate<Class<? extends Entity>> classPredicate = klass ->
+            Modifier.isPublic(klass.getModifiers()) &&
+                    (!klass.isMemberClass() || (klass.isMemberClass() && Modifier
+                            .isStatic(klass.getModifiers()))) &&
+                    !Modifier.isAbstract(klass.getModifiers());
+
+    @SneakyThrows
+    protected GraphQLFieldDefinition getMutation(Class<? extends GraphQLCommand> klass) {
+        return getMutation(klass, (Class) ((ParameterizedType) klass.getAnnotatedSuperclass().getType())
+                .getActualTypeArguments()[0]);
+    }
+
+    @SneakyThrows
+    protected GraphQLFieldDefinition getMutation(Class<? extends GraphQLCommand> klass, Class resultClass) {
+        GraphQLObjectType objectType = GraphQLAnnotations.object(klass);
+        GraphQLObjectType resultType = GraphQLAnnotations.objectBuilder(resultClass)
+                                                         .name(getClass().getSimpleName())
+                                                         .field(newFieldDefinition().name("clientMutationId")
+                                                                                    .type(GraphQLString)
+                                                                                    .dataFetcher(
+                                                                                            e -> ((GraphQLCommand) ((GraphQLContext) e
+                                                                                                    .getContext())
+                                                                                                    .getCommand())
+                                                                                                    .getClientMutationId())
+                                                                                    .build()).build();
+
+        Layout<? extends GraphQLCommand> layout = new Layout<>(klass);
+        GraphQLFieldDefinition.Builder builder = newFieldDefinition()
+                .name(objectType.getName())
+                .type(resultType)
+                .argument(newArgument().name("input")
+                                       .type(new Mutation(
+                                               objectType))
+                                       .build())
+                .dataFetcher(new DataFetcher() {
+                    @SneakyThrows
+                    @Override public Object get(DataFetchingEnvironment environment) {
+                        GraphQLCommand instance = klass.newInstance();
+                        instance.environment(environment);
+
+                        Map<String, Object> input = (Map<String, Object>) environment.getArguments().values()
+                                                                                     .toArray()[0];
+
+                        instance.setClientMutationId((String) input.get("clientMutationId"));
+
+                        for (Property property : layout.getProperties()) {
+                            Object value = input.get(property.getName());
+                            property.set(instance,
+                                         property.getType().isInstanceOf(Optional.class) ? Optional.of(value) : value);
+                        }
+
+                        GraphQLContext context = (GraphQLContext) environment.getContext();
+                        context.setCommand(instance);
+
+                        instance.beforePublishing();
+                        CompletableFuture future = context.getRepository().publish(instance);
+                        return future.get();
+                    }
+                });
+
+        return builder.build();
+    }
+
+    public static class Mutation extends GraphQLInputObjectType {
+        public Mutation(GraphQLObjectType objectType) {
+            super(objectType.getName() + "Input", objectType.getDescription(), fields(objectType));
+        }
+
+        private static List<GraphQLInputObjectField> fields(GraphQLObjectType objectType) {
+            List<GraphQLInputObjectField> fields = new ArrayList<>();
+            for (GraphQLFieldDefinition field : objectType.getFieldDefinitions()) {
+                GraphQLInputObjectField inputField = newInputObjectField()
+                        .name(field.getName())
+                        .description(field.getDescription())
+                        .type(field.getType() instanceof
+                                      GraphQLObjectType ? GraphQLAnnotations
+                                .inputObject(
+                                        (GraphQLObjectType) field
+                                                .getType()) : (GraphQLInputType) field
+                                .getType())
+                        .build();
+                fields.add(inputField);
+            }
+            return fields;
+        }
+    }
+}

--- a/src/main/java/com/eventsourcing/graphql/BundleGraphQLMutationProvider.java
+++ b/src/main/java/com/eventsourcing/graphql/BundleGraphQLMutationProvider.java
@@ -1,0 +1,52 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.graphql;
+
+import graphql.schema.GraphQLFieldDefinition;
+import lombok.SneakyThrows;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.wiring.BundleWiring;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class BundleGraphQLMutationProvider extends AbstractGraphQLMutationProvider {
+
+    private final Class classInABundle;
+
+    public BundleGraphQLMutationProvider(Class classInABundle) {
+        this.classInABundle = classInABundle;
+    }
+
+    @Override public Collection<GraphQLFieldDefinition> getMutations() {
+        return findSubTypesOf(classInABundle, GraphQLCommand.class).stream()
+                          .filter(classPredicate)
+                          .map(this::getMutation)
+                          .collect(Collectors.toSet());
+    }
+
+    private <T> List<Class<? extends T>> findSubTypesOf(Class<?> classInABundle, Class<T> superclass) {
+        BundleWiring wiring = FrameworkUtil.getBundle(classInABundle).adapt(BundleWiring.class);
+        Collection<String> names = wiring
+                .listResources("/" + getClass().getPackage().getName().replaceAll("\\.", "/") + "/",
+                               "*", BundleWiring.LISTRESOURCES_RECURSE);
+        return names.stream().map(new Function<String, Class<?>>() {
+            @Override @SneakyThrows
+            public Class<?> apply(String name) {
+                String n = name.replaceAll("\\.class$", "").replace('/', '.');
+                try {
+                    return BundleGraphQLMutationProvider.this.getClass().getClassLoader().loadClass(n);
+                } catch (ClassNotFoundException e) {
+                    return null;
+                }
+            }
+        }).filter(c -> c != null).filter(superclass::isAssignableFrom)
+                    .map((Function<Class<?>, Class<? extends T>>) aClass -> (Class<? extends T>) aClass)
+                    .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/eventsourcing/graphql/GraphQLCommand.java
+++ b/src/main/java/com/eventsourcing/graphql/GraphQLCommand.java
@@ -6,121 +6,21 @@
 package com.eventsourcing.graphql;
 
 import com.eventsourcing.Command;
-import com.eventsourcing.layout.Layout;
 import com.eventsourcing.layout.LayoutIgnore;
-import com.eventsourcing.layout.Property;
-import graphql.annotations.GraphQLAnnotations;
 import graphql.annotations.GraphQLField;
-import graphql.schema.*;
+import graphql.schema.DataFetchingEnvironment;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.SneakyThrows;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-
-import static graphql.Scalars.GraphQLString;
-import static graphql.schema.GraphQLArgument.newArgument;
-import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
-import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
 
 @Slf4j
 public abstract class GraphQLCommand<R> extends Command<R> {
 
-    private final Class<R> resultClass;
-    private final Layout<? extends GraphQLCommand> layout;
-
-    @SneakyThrows
-    public GraphQLCommand(Class<R> resultClass) {
-        this.resultClass = resultClass;
-        layout = new Layout<>(getClass());
-    }
-
-    private GraphQLFieldDefinition mutation;
+    protected void beforePublishing() {}
 
     @Setter @Getter(onMethod = @__(@LayoutIgnore)) @Accessors(fluent = true)
     private DataFetchingEnvironment environment;
-
-    @SneakyThrows @SuppressWarnings("unchecked")
-    public R mutate(DataFetchingEnvironment environment) {
-        GraphQLCommand instance = getClass().newInstance();
-        instance.environment(environment);
-
-        Map<String, Object> input = (Map<String, Object>) environment.getArguments().values().toArray()[0];
-
-        instance.setClientMutationId((String) input.get("clientMutationId"));
-
-        for (Property property : layout.getProperties()) {
-            Object value = input.get(property.getName());
-            property.set(instance, property.getType().isInstanceOf(Optional.class) ? Optional.of(value) : value);
-        }
-
-        GraphQLContext context = (GraphQLContext) environment.getContext();
-        context.setCommand(instance);
-
-        instance.beforePublishing();
-        CompletableFuture<R> future = context.getRepository().publish(instance);
-        return future.get();
-    }
-
-    protected void beforePublishing() {}
-
-    ;
-
-    public static class Mutation extends GraphQLInputObjectType {
-        public Mutation(GraphQLObjectType objectType) {
-            super(objectType.getName() + "Input", objectType.getDescription(), fields(objectType));
-        }
-
-        private static List<GraphQLInputObjectField> fields(GraphQLObjectType objectType) {
-            List<GraphQLInputObjectField> fields = new ArrayList<>();
-            for (GraphQLFieldDefinition field : objectType.getFieldDefinitions()) {
-                GraphQLInputObjectField inputField = newInputObjectField()
-                        .name(field.getName())
-                        .description(field.getDescription())
-                        .type(field.getType() instanceof
-                                      GraphQLObjectType ? GraphQLAnnotations
-                                .inputObject(
-                                        (GraphQLObjectType) field
-                                                .getType()) : (GraphQLInputType) field
-                                .getType())
-                        .build();
-                fields.add(inputField);
-            }
-            return fields;
-        }
-    }
-
-    @SneakyThrows @LayoutIgnore @SuppressWarnings("unused")
-    public Collection<GraphQLFieldDefinition> getMutations() {
-        if (mutation == null) {
-            GraphQLObjectType objectType = GraphQLAnnotations.object(this.getClass());
-            GraphQLObjectType resultType = GraphQLAnnotations.objectBuilder(resultClass)
-                                                             .name(getClass().getSimpleName())
-                                                             .field(newFieldDefinition().name("clientMutationId")
-                                                                                        .type(GraphQLString)
-                                                                                        .dataFetcher(
-                                                                                                e -> ((GraphQLCommand) ((GraphQLContext) e
-                                                                                                        .getContext())
-                                                                                                        .getCommand())
-                                                                                                        .getClientMutationId())
-                                                                                        .build()).build();
-
-            GraphQLFieldDefinition.Builder builder = newFieldDefinition()
-                    .name(objectType.getName())
-                    .type(resultType)
-                    .argument(newArgument().name("input")
-                                           .type(new Mutation(
-                                                   objectType))
-                                           .build())
-                    .dataFetcher(this::mutate);
-
-            mutation = builder.build();
-        }
-        return Collections.singleton(mutation);
-    }
 
     @Getter(onMethod = @__({@GraphQLField, @LayoutIgnore})) @Setter
     private String clientMutationId;

--- a/src/main/java/com/eventsourcing/graphql/PackageGraphQLMutationProvider.java
+++ b/src/main/java/com/eventsourcing/graphql/PackageGraphQLMutationProvider.java
@@ -1,0 +1,41 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.eventsourcing.graphql;
+
+import graphql.schema.GraphQLFieldDefinition;
+import org.reflections.Configuration;
+import org.reflections.Reflections;
+import org.reflections.util.ConfigurationBuilder;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public class PackageGraphQLMutationProvider extends AbstractGraphQLMutationProvider {
+
+    private final String[] packages;
+    private final ClassLoader[] classLoaders;
+
+    public PackageGraphQLMutationProvider(Package[] packages) {
+        this(packages, new ClassLoader[]{});
+    }
+
+    public PackageGraphQLMutationProvider(Package[] packages, ClassLoader[] classLoaders) {
+        this.packages = Arrays.asList(packages).stream().map(Package::getName).toArray(String[]::new);
+        this.classLoaders = classLoaders;
+    }
+
+
+    @Override public Collection<GraphQLFieldDefinition> getMutations() {
+        Configuration configuration = ConfigurationBuilder.build((Object[]) packages).addClassLoaders(classLoaders);
+        Reflections reflections = new Reflections(configuration);
+        return reflections.getSubTypesOf(GraphQLCommand.class).stream()
+                          .filter(classPredicate)
+                          .map(this::getMutation)
+                          .collect(Collectors.toSet());
+    }
+
+}


### PR DESCRIPTION
This is an unnatural approach since Command itself shouldn't really be a
component that instantiates itself.

Solution: extract scanning GraphQLMutationProvider, for classpath and OSGi.
