### PR TITLE
Problem: Can't use null value in optional fields

### DIFF
--- a/src/main/java/com/eventsourcing/graphql/AbstractGraphQLMutationProvider.java
+++ b/src/main/java/com/eventsourcing/graphql/AbstractGraphQLMutationProvider.java
@@ -79,7 +79,7 @@ public abstract class AbstractGraphQLMutationProvider implements GraphQLMutation
                         for (Property property : layout.getProperties()) {
                             Object value = input.get(property.getName());
                             Object val = property.getTypeHandler() instanceof OptionalTypeHandler ? Optional
-                                    .of(value) : value;
+                                    .ofNullable(value) : value;
                             values.put(property, val);
                         }
 


### PR DESCRIPTION
```
java.lang.NullPointerException: null
    at java.util.Objects.requireNonNull(Objects.java:203) ~[?:1.8.0_66]
    at java.util.Optional.<init>(Optional.java:96) ~[?:1.8.0_66]
    at java.util.Optional.of(Optional.java:108) ~[?:1.8.0_66]
    at com.eventsourcing.graphql.AbstractGraphQLMutationProvider$1.get(AbstractGraphQLMutationProvider.java:82) ~[eventsourcing-graphql-0.4.4.jar:?]
```

Solution: use `Optional.ofNullable`